### PR TITLE
Add CI and ensure compatibility with Symfony 4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: Bundle CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: "Tests ${{ matrix.php-version }} ${{ matrix.dependency-versions }} deps ${{ matrix.dependency-versions }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # normal, highest, non-dev installs
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        composer-options: ['--prefer-stable']
+        dependency-versions: ['highest']
+        include:
+          # testing lowest PHP version with lowest dependencies
+          - php-version: '7.2.5'
+            dependency-versions: 'lowest'
+            composer-options: '--prefer-lowest'
+
+          # testing dev versions with highest PHP
+          - php-version: '8.0'
+            dependency-versions: 'highest'
+            composer-options: '' # allow dev deps
+
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+            coverage: "none"
+            php-version: "${{ matrix.php-version }}"
+
+      - name: Install Global Dependencies
+        run: |
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex @dev
+      - name: "Composer install"
+        uses: "ramsey/composer-install@v1"
+        with:
+            dependency-versions: "${{ matrix.dependency-versions }}"
+            composer-options: "--prefer-dist --no-progress"
+
+      - name: Run tests
+        env:
+          SYMFONY_DEPRECATIONS_HELPER: "max[self]=0"
+          SYMFONY_PHPUNIT_VERSION: "8.5"
+        run: ./vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/serializer": "^4.4 || ^5.0 || ^6.0",
-        "phpoffice/phpspreadsheet": "^1.0.0"
+        "phpoffice/phpspreadsheet": "^1.15.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.3 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.2.5",
-        "symfony/serializer": "^4.4|^5.0",
+        "symfony/serializer": "^4.4 || ^5.0 || ^6.0",
         "phpoffice/phpspreadsheet": "^1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "10.0.x-dev",
-        "symfony/property-access": "6.0.x-dev"
+        "symfony/phpunit-bridge": "^5.3 || ^6.0",
+        "symfony/property-access": "^4.4 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Encoder/XlsxEncoder.php
+++ b/src/Encoder/XlsxEncoder.php
@@ -39,7 +39,7 @@ class XlsxEncoder implements EncoderInterface, DecoderInterface
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 
-    public function encode($data, string $format, array $context = []): string
+    public function encode($data, $format, array $context = []): string
     {
         if (!is_iterable($data)) {
             $data = [[$data]];
@@ -127,12 +127,12 @@ class XlsxEncoder implements EncoderInterface, DecoderInterface
         return $value;
     }
 
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding($format): bool
     {
         return self::FORMAT === $format;
     }
 
-    public function decode(string $data, string $format, array $context = []): array
+    public function decode($data, $format, array $context = []): array
     {
         if (empty($data)) {
             return [];
@@ -190,7 +190,7 @@ class XlsxEncoder implements EncoderInterface, DecoderInterface
         return $result[0];
     }
 
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding($format): bool
     {
         return self::FORMAT === $format;
     }


### PR DESCRIPTION
Thank you for sharing this encoder. We needed to switch an export format from CSV to XLSX and could do it easily with the help of symfony serializer and this encoder.

Unfortunately we couldn't make use of the class by just installing the package, because of an incompatibility with symfony 4.4. The parameter types where added in symfony 5.0.

This PR is supposed to fix this issue.